### PR TITLE
feat(deployment): add build and push to GitHub Container Registry see…

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -69,6 +69,13 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/doclytics:${{ env.BRANCH_NAME }}
           platforms: linux/amd64,linux/arm64
+      - name: Build and push to GitHub Container Registry
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/doclytics:${{ env.BRANCH_NAME }}
+          platforms: linux/amd64,linux/arm64
   release:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -83,4 +83,11 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/doclytics:${{ env.BRANCH_NAME }}
           platforms: linux/amd64,linux/arm64
+      - name: Build and push to GitHub Container Registry
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/doclytics:${{ env.BRANCH_NAME }}
+          platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,3 +66,10 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/doclytics:${{ env.BRANCH_NAME }}
           platforms: linux/amd64,linux/arm64
+      - name: Build and push to GitHub Container Registry
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/doclytics:${{ env.BRANCH_NAME }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
… #56

The workflows for push, release, and production release have been updated to include a step to build the Docker image and push it to the GitHub Container Registry. The changes ensure the Docker images are not only pushed to DockerHub but also to GitHub's own container registry.