### PR TITLE
fix: change archive_serial_number type to u32

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ struct Document {
     created_date: Option<String>,
     modified: String,
     added: String,
-    archive_serial_number: Option<String>,
+    archive_serial_number: Option<u32>,
     original_file_name: Option<String>,
     archived_file_name: Option<String>,
     owner: Option<u32>,


### PR DESCRIPTION
Updated the `archive_serial_number` field from `Option<String>` to `Option<u32>`. This ensures that the serial number is always treated as a numerical value, ensuring type safety and correctness in handling archival data.